### PR TITLE
Add token validation helper and button variants

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,28 +1,40 @@
 import * as React from 'react';
 
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: 'default' | 'secondary' | 'ghost' | 'destructive';
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'default' | 'secondary' | 'ghost' | 'destructive' | 'outline';
   size?: 'sm' | 'md' | 'lg';
 };
+
+const base =
+  'inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
+const variants: Record<string, string> = {
+  default: 'bg-black text-white hover:bg-neutral-800',
+  secondary: 'bg-neutral-200 text-neutral-900 hover:bg-neutral-300',
+  ghost: 'bg-transparent hover:bg-neutral-100',
+  destructive: 'bg-red-600 text-white hover:bg-red-700',
+  outline: 'border border-neutral-200 bg-white hover:bg-neutral-100'
+};
+const sizes: Record<string, string> = {
+  sm: 'h-8 px-3 text-sm',
+  md: 'h-9 px-4 text-sm',
+  lg: 'h-11 px-6 text-base'
+};
+
+export function buttonVariants(options: {
+  variant?: ButtonProps['variant'];
+  size?: ButtonProps['size'];
+  className?: string;
+} = {}) {
+  const { variant = 'default', size = 'md', className = '' } = options;
+  return `${base} ${variants[variant]} ${sizes[size]} ${className}`.trim();
+}
+
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className = '', variant = 'default', size = 'md', ...props }, ref) => {
-    const base =
-      'inline-flex items-center justify-center rounded-md font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
-    const variants: Record<string, string> = {
-      default: 'bg-black text-white hover:bg-neutral-800',
-      secondary: 'bg-neutral-200 text-neutral-900 hover:bg-neutral-300',
-      ghost: 'bg-transparent hover:bg-neutral-100',
-      destructive: 'bg-red-600 text-white hover:bg-red-700'
-    };
-    const sizes: Record<string, string> = {
-      sm: 'h-8 px-3 text-sm',
-      md: 'h-9 px-4 text-sm',
-      lg: 'h-11 px-6 text-base'
-    };
     return (
       <button
         ref={ref}
-        className={`${base} ${variants[variant]} ${sizes[size]} ${className}`}
+        className={buttonVariants({ variant, size, className })}
         {...props}
       />
     );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -30,6 +30,21 @@ async function http<T>(path: string, init?: RequestInit): Promise<T> {
   return (await res.text()) as unknown as T;
 }
 
+export async function validateApiTokenResponse(
+  request: Request,
+  apiToken: string,
+): Promise<Response | undefined> {
+  const authHeader = request.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return Response.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  const token = authHeader.slice('Bearer '.length).trim();
+  if (token !== apiToken) {
+    return Response.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  return undefined;
+}
+
 export async function getMonitoringStatus(): Promise<MonitoringStatus> {
   return http<MonitoringStatus>('/api/monitoring/status');
 }


### PR DESCRIPTION
## Summary
- export `validateApiTokenResponse` to enforce Authorization header
- expose `buttonVariants` helper and add `outline` variant

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beda653b8c832e889f2b7c8b31f50c